### PR TITLE
[PB-14177] Allow Git fetch to be done using HTTPS instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To successfully install and use `smc-upgrader`, you will need the `java` command
 
 ## Connecting to code.elasticpath.com
 
-`smc-upgrader` fetches upgrade commits from the Elastic Path Self-Managed Commerce repository at `code.elasticpath.com`. Before you can use the tool in either Standard Mode or AI Assist Mode, you need to set up authenticated access to that repository over SSH.
+`smc-upgrader` fetches upgrade commits from the Elastic Path Self-Managed Commerce repository at `code.elasticpath.com`. Before you can use the tool in either Standard Mode or AI Assist Mode, you need to set up authenticated access to that repository over SSH or HTTPS.
 
 Complete these steps once per machine. The first `smc-upgrader` run will fail at the fetch step if any of them is skipped.
 
@@ -137,6 +137,12 @@ In your codebase, add `code.elasticpath.com` as a remote called `smc-upgrades`:
 
 ```shell
 git remote add smc-upgrades git@code.elasticpath.com:ep-commerce/ep-commerce.git
+```
+
+If your network blocks SSH access to `code.elasticpath.com`, use HTTPS instead:
+
+```shell
+git remote add smc-upgrades https://code.elasticpath.com/ep-commerce/ep-commerce.git
 ```
 
 ### 6. Verify the connection

--- a/src/main/java/com/elasticpath/tools/smcupgrader/Constants.java
+++ b/src/main/java/com/elasticpath/tools/smcupgrader/Constants.java
@@ -1,24 +1,21 @@
 package com.elasticpath.tools.smcupgrader;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Application-wide constants.
  */
 public final class Constants {
 
 	/**
-	 * The URL of the upstream repository containing SMC release code.
+	 * The supported upstream repository URLs for fetching SMC release code.
 	 */
-	public static final String UPSTREAM_REPO_URL = "git@code.elasticpath.com:ep-commerce/ep-commerce.git";
-
-	/**
-	 * The hostname of the upstream repository, used for protocol-neutral remote detection.
-	 */
-	public static final String UPSTREAM_REPO_HOST = "code.elasticpath.com";
-
-	/**
-	 * The repository path of the upstream repository, used for protocol-neutral remote detection.
-	 */
-	public static final String UPSTREAM_REPO_PATH = "ep-commerce/ep-commerce";
+	public static final List<String> UPSTREAM_REPO_URLS = Collections.unmodifiableList(Arrays.asList(
+			"git@code.elasticpath.com:ep-commerce/ep-commerce.git",
+			"https://code.elasticpath.com/ep-commerce/ep-commerce.git"
+	));
 
 	/**
 	 * The file name for the upgrade plan.

--- a/src/main/java/com/elasticpath/tools/smcupgrader/Constants.java
+++ b/src/main/java/com/elasticpath/tools/smcupgrader/Constants.java
@@ -11,6 +11,16 @@ public final class Constants {
 	public static final String UPSTREAM_REPO_URL = "git@code.elasticpath.com:ep-commerce/ep-commerce.git";
 
 	/**
+	 * The hostname of the upstream repository, used for protocol-neutral remote detection.
+	 */
+	public static final String UPSTREAM_REPO_HOST = "code.elasticpath.com";
+
+	/**
+	 * The repository path of the upstream repository, used for protocol-neutral remote detection.
+	 */
+	public static final String UPSTREAM_REPO_PATH = "ep-commerce/ep-commerce";
+
+	/**
 	 * The file name for the upgrade plan.
 	 */
 	public static final String PLAN_FILE_NAME = "smc-upgrader-plan.md";

--- a/src/main/java/com/elasticpath/tools/smcupgrader/UpstreamRemoteManager.java
+++ b/src/main/java/com/elasticpath/tools/smcupgrader/UpstreamRemoteManager.java
@@ -32,7 +32,7 @@ public class UpstreamRemoteManager {
 		}
 
 		final Optional<String> existingRemoteRepositoryName = gitClient.getRemoteRepositories().stream()
-				.filter(remoteRepository -> remoteRepository.getUrl().contains(Constants.UPSTREAM_REPO_URL))
+				.filter(remoteRepository -> isUpstreamUrl(remoteRepository.getUrl()))
 				.map(RemoteRepository::getName)
 				.findFirst();
 
@@ -45,13 +45,9 @@ public class UpstreamRemoteManager {
 				+ "git remote add " + UPGRADE_REMOTE_NAME + " " + Constants.UPSTREAM_REPO_URL);
 	}
 
-	/**
-	 * Returns the name to use for the upstream remote containing upgrade commits when that remote has not already been set on the working
-	 * Git repository.
-	 *
-	 * @return the name to use for the upstream remote containing upgrade commits
-	 */
-	protected String createRemoteRepositoryName() {
-		return UPGRADE_REMOTE_NAME;
+	private static boolean isUpstreamUrl(final String url) {
+		return url != null
+				&& url.contains(Constants.UPSTREAM_REPO_HOST)
+				&& url.contains(Constants.UPSTREAM_REPO_PATH);
 	}
 }

--- a/src/main/java/com/elasticpath/tools/smcupgrader/UpstreamRemoteManager.java
+++ b/src/main/java/com/elasticpath/tools/smcupgrader/UpstreamRemoteManager.java
@@ -1,6 +1,7 @@
 package com.elasticpath.tools.smcupgrader;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Manages the configuration for upstream remote repositories.
@@ -41,13 +42,19 @@ public class UpstreamRemoteManager {
 			return remoteRepositoryName;
 		}
 
-		throw new LoggableException("No upstream repository found in git configuration. Please add the remote via the following command:\n\n"
-				+ "git remote add " + UPGRADE_REMOTE_NAME + " " + Constants.UPSTREAM_REPO_URL);
+		final String commands = Constants.UPSTREAM_REPO_URLS.stream()
+				.map(url -> "git remote add " + UPGRADE_REMOTE_NAME + " " + url)
+				.collect(Collectors.joining("\n"));
+
+		throw new LoggableException("No upstream repository found in git configuration."
+				+ " Please add the remote via one of the following commands:\n\n" + commands);
 	}
 
 	private static boolean isUpstreamUrl(final String url) {
-		return url != null
-				&& url.contains(Constants.UPSTREAM_REPO_HOST)
-				&& url.contains(Constants.UPSTREAM_REPO_PATH);
+		if (url == null) {
+			return false;
+		}
+		final String normalizedUrl = url.replaceFirst("://[^@]+@", "://");
+		return Constants.UPSTREAM_REPO_URLS.contains(normalizedUrl);
 	}
 }

--- a/src/test/java/com/elasticpath/tools/smcupgrader/UpstreamRemoteManagerTest.java
+++ b/src/test/java/com/elasticpath/tools/smcupgrader/UpstreamRemoteManagerTest.java
@@ -34,7 +34,7 @@ class UpstreamRemoteManagerTest {
 
 	@Test
 	public void verifyRemoteNameReturnedWhenSshUrl() {
-		givenUpstreamRemote(Constants.UPSTREAM_REPO_URL);
+		givenUpstreamRemote(Constants.UPSTREAM_REPO_URLS.get(0));
 
 		assertThat(upstreamRemoteManager.getUpstreamRemoteName()).isEqualTo(REMOTE_REPO_NAME);
 	}

--- a/src/test/java/com/elasticpath/tools/smcupgrader/UpstreamRemoteManagerTest.java
+++ b/src/test/java/com/elasticpath/tools/smcupgrader/UpstreamRemoteManagerTest.java
@@ -2,7 +2,6 @@ package com.elasticpath.tools.smcupgrader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -21,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class UpstreamRemoteManagerTest {
 
 	private static final String REMOTE_REPO_NAME = "upstream";
+	private static final String NON_MATCHING_URL = "git@example.com/otherproject.git";
 
 	@Mock
 	private GitClient gitClient;
@@ -29,26 +29,41 @@ class UpstreamRemoteManagerTest {
 
 	@BeforeEach
 	public void setUp() {
-		upstreamRemoteManager = spy(new UpstreamRemoteManager(gitClient));
+		upstreamRemoteManager = new UpstreamRemoteManager(gitClient);
 	}
 
 	@Test
-	public void verifyRemoteNameReturnedWhenFound() {
-		final RemoteRepository repoOther = new RemoteRepository("otherName", "git@example.com/otherproject.git");
-		final RemoteRepository upstreamRepo = new RemoteRepository(REMOTE_REPO_NAME, Constants.UPSTREAM_REPO_URL);
-
-		when(gitClient.getRemoteRepositories())
-				.thenReturn(Sets.newLinkedHashSet(repoOther, upstreamRepo));
+	public void verifyRemoteNameReturnedWhenSshUrl() {
+		givenUpstreamRemote(Constants.UPSTREAM_REPO_URL);
 
 		assertThat(upstreamRemoteManager.getUpstreamRemoteName()).isEqualTo(REMOTE_REPO_NAME);
 	}
 
 	@Test
-	public void verifyExceptionThrownWhenNotFound() {
-		final RemoteRepository repoOther = new RemoteRepository("otherName", "git@example.com/otherproject.git");
+	public void verifyRemoteNameReturnedWhenHttpsUrl() {
+		givenUpstreamRemote("https://code.elasticpath.com/ep-commerce/ep-commerce.git");
 
-		when(gitClient.getRemoteRepositories())
-				.thenReturn(Sets.newLinkedHashSet(repoOther));
+		assertThat(upstreamRemoteManager.getUpstreamRemoteName()).isEqualTo(REMOTE_REPO_NAME);
+	}
+
+	@Test
+	public void verifyRemoteNameReturnedWhenHttpsUrlWithToken() {
+		givenUpstreamRemote("https://oauth2:glpat-XXXX@code.elasticpath.com/ep-commerce/ep-commerce.git");
+
+		assertThat(upstreamRemoteManager.getUpstreamRemoteName()).isEqualTo(REMOTE_REPO_NAME);
+	}
+
+	@Test
+	public void verifyExceptionThrownWhenSamePathButDifferentHost() {
+		givenOnlyNonMatchingRemotes("https://other-host.com/ep-commerce/ep-commerce.git");
+
+		assertThatThrownBy(() -> upstreamRemoteManager.getUpstreamRemoteName())
+				.isInstanceOf(LoggableException.class);
+	}
+
+	@Test
+	public void verifyExceptionThrownWhenNotFound() {
+		givenOnlyNonMatchingRemotes(NON_MATCHING_URL);
 
 		assertThatThrownBy(() -> upstreamRemoteManager.getUpstreamRemoteName())
 				.isInstanceOf(LoggableException.class);
@@ -63,4 +78,16 @@ class UpstreamRemoteManagerTest {
 				.isInstanceOf(LoggableException.class);
 	}
 
+	private void givenUpstreamRemote(final String upstreamUrl) {
+		final RemoteRepository repoOther = new RemoteRepository("otherName", NON_MATCHING_URL);
+		final RemoteRepository upstreamRepo = new RemoteRepository(REMOTE_REPO_NAME, upstreamUrl);
+
+		when(gitClient.getRemoteRepositories())
+				.thenReturn(Sets.newLinkedHashSet(repoOther, upstreamRepo));
+	}
+
+	private void givenOnlyNonMatchingRemotes(final String url) {
+		when(gitClient.getRemoteRepositories())
+				.thenReturn(Sets.newLinkedHashSet(new RemoteRepository("otherName", url)));
+	}
 }


### PR DESCRIPTION
The `smc-upgrader` currently only detects the upstream when `smc-upgrades` remote is configured with SSH url, but client's network might block SSH to http://code.elasticpath.com/ , so the tool won't find the remote and fails. We could do something like matching protocol-neutral path fragment `ep-commerce/ep-commerce` which is shared.