### PR TITLE
[SUP-6864] Preserve allowManualValidation flag through plan generation

### DIFF
--- a/src/main/java/com/elasticpath/tools/smcupgrader/ai/AiPlanExecutor.java
+++ b/src/main/java/com/elasticpath/tools/smcupgrader/ai/AiPlanExecutor.java
@@ -15,11 +15,9 @@
 
 package com.elasticpath.tools.smcupgrader.ai;
 
-import java.io.BufferedReader;
 import java.io.Console;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -601,7 +599,7 @@ public class AiPlanExecutor {
 	}
 
 	/**
-	 * Run a validation command.
+	 * Run a validation command, streaming its output directly to the terminal.
 	 *
 	 * @param command the command to run
 	 * @return true if the command exited with code 0
@@ -611,17 +609,8 @@ public class AiPlanExecutor {
 		try {
 			Process process = new ProcessBuilder("/bin/sh", "-c", command)
 					.directory(workingDir)
-					.redirectErrorStream(true)
+					.inheritIO()
 					.start();
-
-			// Read output
-			try (BufferedReader reader = new BufferedReader(
-					new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-				String line;
-				while ((line = reader.readLine()) != null) {
-					LOGGER.debug("Validation output: {}", line);
-				}
-			}
 
 			int exitCode = process.waitFor();
 			return exitCode == 0;

--- a/src/main/java/com/elasticpath/tools/smcupgrader/ai/AiPlanGenerator.java
+++ b/src/main/java/com/elasticpath/tools/smcupgrader/ai/AiPlanGenerator.java
@@ -242,6 +242,7 @@ public class AiPlanGenerator {
 				step.setStatus(template.getStatus() != null ? template.getStatus() : StatusEnum.NOT_STARTED);
 				step.setCommitPlanOnCompletion(template.isCommitPlanOnCompletion());
 				step.setCommitAllChangesOnCompletion(template.isCommitAllChangesOnCompletion());
+				step.setAllowManualValidation(template.isAllowManualValidation());
 				step.setVersion(toVersion);
 
 				if (template.getValidationCommand() != null) {

--- a/src/main/java/com/elasticpath/tools/smcupgrader/ai/MarkdownParser.java
+++ b/src/main/java/com/elasticpath/tools/smcupgrader/ai/MarkdownParser.java
@@ -51,6 +51,7 @@ public final class MarkdownParser {
 	private static final Pattern VALIDATION_PATTERN = Pattern.compile("Validation command:\\s*(.+)");
 	private static final Pattern COMMIT_ALL_CHANGES_PATTERN = Pattern.compile("Commit all changes on completion:\\s*(.+)");
 	private static final Pattern COMMIT_PLAN_PATTERN = Pattern.compile("Commit plan on completion:\\s*(.+)");
+	private static final Pattern ALLOW_MANUAL_VALIDATION_PATTERN = Pattern.compile("Allow manual validation:\\s*(.+)");
 	private static final Pattern STATUS_PATTERN = Pattern.compile("Status:\\s*(.+)");
 
 	private MarkdownParser() {
@@ -224,6 +225,13 @@ public final class MarkdownParser {
 			matcher = COMMIT_PLAN_PATTERN.matcher(line);
 			if (matcher.find()) {
 				currentStep.setCommitPlanOnCompletion(Boolean.parseBoolean(matcher.group(1).trim()));
+				foundMetadata = true;
+				continue;
+			}
+
+			matcher = ALLOW_MANUAL_VALIDATION_PATTERN.matcher(line);
+			if (matcher.find()) {
+				currentStep.setAllowManualValidation(Boolean.parseBoolean(matcher.group(1).trim()));
 				foundMetadata = true;
 				continue;
 			}

--- a/src/main/java/com/elasticpath/tools/smcupgrader/ai/MarkdownWriter.java
+++ b/src/main/java/com/elasticpath/tools/smcupgrader/ai/MarkdownWriter.java
@@ -102,6 +102,7 @@ public final class MarkdownWriter {
 
 		markdown.append("Commit all changes on completion: ").append(step.isCommitAllChangesOnCompletion()).append("\n");
 		markdown.append("Commit plan on completion: ").append(step.isCommitPlanOnCompletion()).append("\n");
+		markdown.append("Allow manual validation: ").append(step.isAllowManualValidation()).append("\n");
 		markdown.append("Status: ").append(step.getStatus() != null ? step.getStatus().getValue() : "").append("\n\n");
 
 		// Prompt for LLM steps

--- a/src/test/java/com/elasticpath/tools/smcupgrader/ai/AiPlanExecutorTest.java
+++ b/src/test/java/com/elasticpath/tools/smcupgrader/ai/AiPlanExecutorTest.java
@@ -64,8 +64,8 @@ class AiPlanExecutorTest {
 		doNothing().when(gitClient).commit(anyString());
 
 		// Configure mock LLM invoker to always return false (LLM not available)
-		when(llmInvoker.isLlmAvailable()).thenReturn(false);
-		when(llmInvoker.invoke(anyString())).thenReturn(false);
+		when(llmInvoker.isLlmAvailable()).thenReturn(Boolean.valueOf(false));
+		when(llmInvoker.invoke(anyString())).thenReturn(Boolean.valueOf(false));
 
 		// Create executor with overridden methods to use mocks and prevent real process execution
 		executor = new AiPlanExecutor(tempDir, gitClient) {
@@ -526,6 +526,65 @@ class AiPlanExecutorTest {
 		// Step should be marked complete (no recipes dir → graceful skip)
 		PlanDocument plan = readPlanFile();
 		assertThat(plan.getSteps().get(0).getStatus()).isEqualTo(StatusEnum.COMPLETE);
+	}
+
+	@Test
+	void testExecuteNextStep_allowManualValidationFalse_rejectsV() throws IOException {
+		// When allowManualValidation is false, choosing V from the menu should be rejected.
+		AiPlanStep step = createStep("Server startup", "llm", "in progress");
+		step.setValidationCommand("mvn tomcat8:run-war");
+		step.setAllowManualValidation(false);
+		step.setCommitAllChangesOnCompletion(false);
+
+		writePlanFile(Arrays.asList(step));
+
+		executor.setTestChoice("V");
+		boolean result = executor.executeNextStep();
+
+		// Should return false because manual validation is not allowed
+		assertThat(result).isFalse();
+
+		// Step should remain in progress
+		PlanDocument plan = readPlanFile();
+		assertThat(plan.getSteps().get(0).getStatus()).isEqualTo(StatusEnum.IN_PROGRESS);
+	}
+
+	@Test
+	void testExecuteNextStep_allowManualValidationTrue_acceptsV() throws IOException {
+		// When allowManualValidation is true (default), V should work normally.
+		AiPlanStep step = createStep("Compilation check", "llm", "in progress");
+		step.setValidationCommand("exit 0");
+		step.setAllowManualValidation(true);
+
+		writePlanFile(Arrays.asList(step));
+
+		executor.setTestChoice("V");
+		boolean result = executor.executeNextStep();
+
+		assertThat(result).isTrue();
+
+		// Validation passed, step should be complete
+		PlanDocument plan = readPlanFile();
+		assertThat(plan.getSteps().get(0).getStatus()).isEqualTo(StatusEnum.COMPLETE);
+	}
+
+	@Test
+	void testExecuteNextStep_allowManualValidationFalse_roundTripThroughPlanFile() throws IOException {
+		// Verify the flag survives the full cycle: write plan → parse → save → reparse.
+		AiPlanStep step = createStep("Server startup", "llm", "not started");
+		step.setAllowManualValidation(false);
+		step.setPrompt("Start the server.");
+		step.setCommitAllChangesOnCompletion(false);
+
+		writePlanFile(Arrays.asList(step));
+
+		// Execute to mark in progress (will save plan)
+		boolean result = executor.executeNextStep();
+		assertThat(result).isTrue();
+
+		// Re-read the plan and verify the flag was preserved through the save
+		PlanDocument plan = readPlanFile();
+		assertThat(plan.getSteps().get(0).isAllowManualValidation()).isFalse();
 	}
 
 	@Test

--- a/src/test/java/com/elasticpath/tools/smcupgrader/ai/AiPlanGeneratorTest.java
+++ b/src/test/java/com/elasticpath/tools/smcupgrader/ai/AiPlanGeneratorTest.java
@@ -475,6 +475,35 @@ class AiPlanGeneratorTest {
 		assertThat(content).doesNotContain("Existing plan");
 	}
 
+	@Test
+	void testExpandStepsForVersions_copiesAllowManualValidation() {
+		// Create upgrade path with a step that has allowManualValidation=false
+		AiPlanStep templateFalse = createStep("Server startup for {TO_VERSION}", "llm", "mvn tomcat8:run-war");
+		templateFalse.setAllowManualValidation(false);
+
+		AiPlanStep templateTrue = createStep("Resolve {TO_VERSION} compilation issues", "llm", "mvn clean install");
+		// allowManualValidation defaults to true
+
+		List<VersionEntry> versions = Arrays.asList(
+				new VersionEntry("8.5.x", ""),
+				new VersionEntry("8.6.x", "")
+		);
+		AiAssistConfigModel config = new AiAssistConfigModel(versions, "", "",
+				Arrays.asList(templateFalse, templateTrue));
+		AiPlanGenerator gen = new AiPlanGenerator(config, upgradeController) {
+			@Override
+			protected GitClient createGitClient(final File workingDir) {
+				return null;
+			}
+		};
+
+		List<AiPlanStep> steps = gen.expandStepsForVersions(Arrays.asList("8.5.x", "8.6.x"));
+
+		assertThat(steps).hasSize(2);
+		assertThat(steps.get(0).isAllowManualValidation()).isFalse();
+		assertThat(steps.get(1).isAllowManualValidation()).isTrue();
+	}
+
 	/**
 	 * Helper method to create a test step.
 	 */

--- a/src/test/java/com/elasticpath/tools/smcupgrader/ai/MarkdownParserTest.java
+++ b/src/test/java/com/elasticpath/tools/smcupgrader/ai/MarkdownParserTest.java
@@ -211,6 +211,68 @@ class MarkdownParserTest {
 	}
 
 	@Test
+	void testParsePlan_allowManualValidationFalse() {
+		String markdown = "# SMC Upgrader - AI Assist Plan\n\n"
+				+ "## Server startup\n\n"
+				+ "Tool: llm\n"
+				+ "Commit all changes on completion: false\n"
+				+ "Commit plan on completion: false\n"
+				+ "Allow manual validation: false\n"
+				+ "Status: not started\n\n"
+				+ "Start the server.\n\n";
+
+		PlanDocument plan = MarkdownParser.parsePlan(markdown);
+
+		assertThat(plan.getSteps()).hasSize(1);
+		assertThat(plan.getSteps().get(0).isAllowManualValidation()).isFalse();
+	}
+
+	@Test
+	void testParsePlan_allowManualValidationAbsentDefaultsToTrue() {
+		// Plan files generated before this feature contain no Allow manual validation line.
+		// The field default of true must be preserved.
+		String markdown = "# SMC Upgrader - AI Assist Plan\n\n"
+				+ "## Resolve compilation issues\n\n"
+				+ "Tool: llm\n"
+				+ "Commit all changes on completion: true\n"
+				+ "Commit plan on completion: true\n"
+				+ "Status: not started\n\n"
+				+ "Fix compilation.\n\n";
+
+		PlanDocument plan = MarkdownParser.parsePlan(markdown);
+
+		assertThat(plan.getSteps()).hasSize(1);
+		assertThat(plan.getSteps().get(0).isAllowManualValidation()).isTrue();
+	}
+
+	@Test
+	void testParsePlan_roundTrip_allowManualValidation() {
+		// Verify both true and false survive a write-then-reparse cycle.
+		AiPlanStep stepFalse = new AiPlanStep();
+		stepFalse.setTitle("Server startup");
+		stepFalse.setTool(ToolTypeEnum.LLM);
+		stepFalse.setStatus(StatusEnum.NOT_STARTED);
+		stepFalse.setAllowManualValidation(false);
+		stepFalse.setPrompt("Start the server.");
+
+		AiPlanStep stepTrue = new AiPlanStep();
+		stepTrue.setTitle("Resolve compilation issues");
+		stepTrue.setTool(ToolTypeEnum.LLM);
+		stepTrue.setStatus(StatusEnum.NOT_STARTED);
+		stepTrue.setAllowManualValidation(true);
+		stepTrue.setPrompt("Fix compilation.");
+
+		String markdown = MarkdownWriter.generateMarkdown(
+				java.util.Arrays.asList(stepFalse, stepTrue), "8.5.x", "8.6.x");
+
+		PlanDocument plan = MarkdownParser.parsePlan(markdown);
+
+		assertThat(plan.getSteps()).hasSize(2);
+		assertThat(plan.getSteps().get(0).isAllowManualValidation()).isFalse();
+		assertThat(plan.getSteps().get(1).isAllowManualValidation()).isTrue();
+	}
+
+	@Test
 	void testParsePlan_roundTripWithRealLengthPrompt() {
 		// The existing round-trip test uses a very short prompt. This test uses a long, realistic
 		// prompt similar to what the actual ai-assist-config.json generates, including special


### PR DESCRIPTION
 Fix `allowManualValidation` being lost during plan generation and plan file save/load. Make validation command output visible by switching to `inheritIO()`.